### PR TITLE
feature: allow certain labels to be dropped from document

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+omit =
+    */homebrew/*

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -29,7 +29,7 @@ jobs:
           pip install -r tests/test-requirements.txt
       - name: Run tests with coverage
         run: |
-          python -m coverage run -m unittest
+         python -m coverage run -m unittest discover -v
       - name: Generate a coverage report with a minimum coverage threshold
         run: |
           python -m coverage report --fail-under=90

--- a/.github/workflows/unittest_badge.yaml
+++ b/.github/workflows/unittest_badge.yaml
@@ -25,7 +25,7 @@ jobs:
           pip install -r tests/test-requirements.txt
       - name: Generate coverage report
         run: |
-          python -m coverage run -m unittest
+          python -m coverage run -m unittest discover -v
           python -m coverage report > coverage_output.log
       - name: Generate badge
         run: |

--- a/README.md
+++ b/README.md
@@ -11,13 +11,12 @@ files. In line with GitOps practices, a shallow or non-nested structure for save
 visibility and clarity. Requires Python 3.7+
 
 ```text
-❯ python -m helmYAMLizer --help
-usage: helmYAMLizer.py [-h] -d DIR [--debug]
-
 optional arguments:
-  -h, --help         show this help message and exit
-  -d DIR, --dir DIR  The directory where files will be saved.
-  --debug            Should we run the script in debug mode?
+  -h, --help            show this help message and exit
+  -d DIR, --dir DIR     The directory where files will be saved.
+  --drop-label-keys [DROP_LABEL_KEYS ...]
+                        List of metadata label keys to remove.
+  --debug               Should we run the script in debug mode?
 ```
 
 ### Usage

--- a/tests/test_drop_label_keys.py
+++ b/tests/test_drop_label_keys.py
@@ -1,0 +1,80 @@
+# pylint: disable=missing-module-docstring
+# pylint: disable=no-name-in-module
+
+import unittest
+from unittest.mock import patch
+from helmYAMLizer import drop_label_keys
+from .utils import check_expected_logging_call
+
+
+class TestDropLabelKeys(unittest.TestCase):
+    """'drop_label_keys' function test cases."""
+
+    def test_basic_case(self):
+        """Testing a basic dictionary structure with some labels to drop."""
+        data = {
+            "name": "test",
+            "labels": {"a": "value_a", "b": "value_b"},
+            "details": "Some details",
+        }
+        label_keys = ["a"]
+        expected = {
+            "name": "test",
+            "labels": {"b": "value_b"},
+            "details": "Some details",
+        }
+        self.assertEqual(drop_label_keys(data, label_keys), expected)
+
+    def test_recursive_case(self):
+        """Testing a dictionary that has nested dictionaries containing labels."""
+        data = {
+            "name": "test",
+            "labels": {"a": "value_a", "b": "value_b"},
+            "details": {"labels": {"a": "value_a_nested", "c": "value_c"}},
+        }
+        label_keys = ["a"]
+        expected = {
+            "name": "test",
+            "labels": {"b": "value_b"},
+            "details": {"labels": {"c": "value_c"}},
+        }
+        self.assertEqual(drop_label_keys(data, label_keys), expected)
+
+    def test_list_case(self):
+        """Testing a dictionary that contains a list of dictionaries with labels."""
+        data = {
+            "name": "test",
+            "items": [
+                {"labels": {"a": "value_a", "b": "value_b"}},
+                {"labels": {"a": "value_a_nested", "c": "value_c"}},
+            ],
+        }
+        label_keys = ["a"]
+        expected = {
+            "name": "test",
+            "items": [{"labels": {"b": "value_b"}}, {"labels": {"c": "value_c"}}],
+        }
+        self.assertEqual(drop_label_keys(data, label_keys), expected)
+
+    @patch("helmYAMLizer.sys.exit")
+    @patch("helmYAMLizer.logging.fatal")
+    def test_invalid_label_keys(self, mock_logging, mock_exit):
+        """Testing with invalid label keys (not all are strings)."""
+        data = {"name": "test"}
+        label_keys = ["a", 123]
+        drop_label_keys(data, label_keys)
+        error_msg = "label_keys must be a list of strings."
+        self.assertTrue(
+            check_expected_logging_call(
+                mock_logging, "drop_label_keys", ValueError, error_msg
+            ),
+            "Expected logging call not found.",
+        )
+        # Check if sys.exit(1) was called.
+        mock_exit.assert_called_once_with(1)
+
+    def test_non_dict_or_list_data(self):
+        """Testing with a data type that is neither dictionary nor list."""
+        data = "Some string data"
+        label_keys = ["a"]
+        self.assertEqual(drop_label_keys(data, label_keys), data)


### PR DESCRIPTION
This feature is particularly useful to remove metadata labels of a `app.kubernetes.io/managed-by: Helm` kind.  